### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/janirius/snake_game/security/code-scanning/1](https://github.com/janirius/snake_game/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow deploys to GitHub Pages, it requires `contents: write` permissions. We will add this block at the root level of the workflow to apply it to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to complete the task.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
